### PR TITLE
bumping to current Ruby in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.5.5'
+ruby '2.5.8'
 
 gem 'bcrypt', '3.1.13'
 gem 'puma', '4.3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ DEPENDENCIES
   webpacker (~> 5.1)
 
 RUBY VERSION
-   ruby 2.5.5p157
+   ruby 2.5.8p224
 
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
To solve the `Your Ruby version is 2.5.8, but your Gemfile specified 2.5.5` complaint.