### PR TITLE
create pids dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ ENV APP_ROOT /app
 RUN mkdir -p $APP_ROOT
 WORKDIR $APP_ROOT
 
+RUN mkdir -p tmp/pids
+RUN touch tmp/pids/server.pid
+
 # Preinstall gems in an earlier layer so we don't reinstall every time any file changes.
 COPY Gemfile  $APP_ROOT
 COPY Gemfile.lock $APP_ROOT


### PR DESCRIPTION
Trying to get this to run on Container Station on my QNAP. The error I'm encountering is:

```
Errno::ENOENT: No such file or directory @ rb_sysopen - tmp/pids/server.pid                                                                              
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `initialize'                                                                             
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `open'                                                                                   
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/launcher.rb:233:in `write_pid'                                                                              
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/launcher.rb:102:in `write_state'                                                                            
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/single.rb:48:in `run'                                                                                       
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/launcher.rb:171:in `run'                                                                                    
  /usr/local/bundle/gems/puma-5.0.4/lib/puma/cli.rb:80:in `run'                                                                                          
  /usr/local/bundle/gems/puma-5.0.4/bin/puma:10:in `<top (required)>'                                                                                    
  /usr/local/bundle/bin/puma:23:in `load'                                                                                                                
  /usr/local/bundle/bin/puma:23:in `<top (required)>'    
```